### PR TITLE
Allow users to update their list of gateways

### DIFF
--- a/test
+++ b/test
@@ -3,4 +3,6 @@
 sudo rm -rf /usr/lib/pia-manager
 sudo rm -rf /usr/share/pia-manager
 sudo cp -R usr /
+
+# sudo pia-manager --update-gateways
 pia-manager

--- a/usr/bin/pia-manager
+++ b/usr/bin/pia-manager
@@ -1,5 +1,54 @@
 #!/usr/bin/python3
 
-import os, getpass
+import os, sys, getpass
 
+import json
+import urllib.request
+
+
+def update_gateways(use_ips):
+    """Updates the list of PIA gateways. If `use_ips` is true, store IP addresses rather than hostnames."""
+    # TODO: also update the CRL from this call, can be handled in similar way most likely.
+    # grab new gateway json
+    response = urllib.request.urlopen('https://privateinternetaccess.com/vpninfo/servers?version=24')
+    data = response.read()
+    text = data.decode('utf-8')
+
+    # split json from CRL blob
+    server_info_text, crl = text.split('\n\n')
+    server_info = json.loads(server_info_text)
+
+    # assemble file that the manager uses
+    gateway_info = {}
+    for key, info in server_info.items():
+        if key == 'info':
+            continue
+
+        host = info['dns']
+        if use_ips:
+            host = info['openvpn_udp']['best'].split(':')[0]
+        gateway_info[key] = '{host} {name}'.format(host=host, name=info['name'])
+
+    # arrange by the region list we prefer
+    gateway_list = []
+    for key in server_info['info']['auto_regions']:
+        gateway_list.append(gateway_info[key])
+
+    gateways = '\n'.join(gateway_list)
+
+    # write out file
+    with open('/usr/share/pia-manager/gateways.list.dynamic', 'w') as fp:
+        fp.write(gateways)
+
+
+# if they just want to update the gateways, we can do it here
+if __name__ == "__main__":
+    # bit hacky, but it should work fine until we want to use docopt or something
+    if '--update-gateways' in sys.argv:
+        # use-ups is recommended if they are heading to an area that implements DNS blocks against PIA
+        use_ips = '--use-ips' in sys.argv
+        update_gateways(use_ips)
+        sys.exit(0)
+
+# launch the regular app
 os.system("gksu /usr/lib/pia-manager/pia-manager.py '%s'" % getpass.getuser())

--- a/usr/lib/pia-manager/pia-manager.py
+++ b/usr/lib/pia-manager/pia-manager.py
@@ -12,8 +12,6 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gio
 
 
-
-
 # i18n
 gettext.install("pia-manager", "/usr/share/locale")
 
@@ -92,17 +90,25 @@ class Manager(Gtk.Application):
         # Gateway combo
         model = Gtk.ListStore(str, str) #id, name
         selected_iter = None
-        with open('/usr/share/pia-manager/gateways.list') as fp:
-            for line in fp:
-                line = line.strip()
-                if not line.startswith("#"):
-                    bits = line.split()
-                    if len(bits) >= 2:
-                        gateway_id = bits[0]
-                        gateway_name = " ".join(bits[1:])
-                        iter = model.append([gateway_id, gateway_name])
-                        if gateway_id == self.gateway_value:
-                            selected_iter = iter
+        # load list of gateways
+        gateway_info = []
+        try:
+            with open('/usr/share/pia-manager/gateways.list.dynamic') as fp:
+                gateway_info = fp.readlines()
+        except IOError:
+            with open('/usr/share/pia-manager/gateways.list') as fp:
+                gateway_info = fp.readlines()
+
+        for line in gateway_info:
+            line = line.strip()
+            if not line.startswith("#"):
+                bits = line.split()
+                if len(bits) >= 2:
+                    gateway_id = bits[0]
+                    gateway_name = " ".join(bits[1:])
+                    iter = model.append([gateway_id, gateway_name])
+                    if gateway_id == self.gateway_value:
+                        selected_iter = iter
 
         self.gateway.set_model(model)
 


### PR DESCRIPTION
This PR adds this command:
```
pia-manager --update-gateways [--use-ips]
```

Essentially, `--update-gateways` downloads the new list of servers and then writes the output to the file `/usr/share/pia-manager/gateways.list.dynamic`. On the actual GUI side, if the `.dynamic` file exists it prefers that – and otherwise it grabs it from the usual location.

There are certainly ways to improve this going forward. I'm thinking we can make the actual code that handles `--update-gateways` a part of the `usr/lib/pia-manager/pia-manager.py` script. The reason I haven't done this yet is just because of the interesting `getpass.getuser()` stuff that the bin script does.

The good thing about doing this is that we can have a button on the interface called something like "Update server list", would make actually using this a bunch easier for users than having to go use a terminal command. As well, we'd also be able to add i10n for the outputs there.

The `--use-ips` option wouldn't be used too much, but it's mostly useful when users are heading to places that do weird DNS blocking, so supporting it as well is a good idea.